### PR TITLE
Draft: Reintegrate frontend CI tests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,107 +31,107 @@ jobs:
       - name: Build Vue app
         run: yarn run build
 
-#  test-e2e:
-#    runs-on: ubuntu-latest
-#    services:
-#      postgres:
-#        image: postgres:latest
-#        env:
-#          POSTGRES_DB: django
-#          POSTGRES_PASSWORD: postgres
-#        ports:
-#          - 5432:5432
-#      rabbitmq:
-#        image: rabbitmq:management
-#        ports:
-#          - 5672:5672
-#      minio:
-#        # This image does not require any command arguments (which GitHub Actions don't support)
-#        image: bitnami/minio:latest
-#        env:
-#          MINIO_ROOT_USER: minioAccessKey
-#          MINIO_ROOT_PASSWORD: minioSecretKey
-#        ports:
-#          - 9000:9000
-#    env:
-#      # API server env vars
-#      DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
-#      DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
-#      DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
-#      DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
-#      DJANGO_STORAGE_BUCKET_NAME: dandi-bucket
-#      DJANGO_DANDI_DANDISETS_BUCKET_NAME: dandi-bucket
-#      DJANGO_DANDI_DANDISETS_LOG_BUCKET_NAME: dandiapi-dandisets-logs
-#      DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_NAME: dandi-embargo-dandisets
-#      DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME: dandiapi-embargo-dandisets-logs
-#      DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
-#      DJANGO_DANDI_API_URL: http://localhost:8000
-#      DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org/
-#      DANDI_ALLOW_LOCALHOST_URLS: 1
-#
-#      # Web client env vars
-#      VITE_APP_DANDI_API_ROOT: http://localhost:8000/api/
-#      VITE_APP_OAUTH_API_ROOT: http://localhost:8000/oauth/
-#      VITE_APP_OAUTH_CLIENT_ID: Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl
-#
-#      # E2E tests env vars
-#      CLIENT_URL: http://localhost:8085
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - uses: actions/setup-node@v4
-#        with:
-#          cache: 'yarn'
-#          cache-dependency-path: web/yarn.lock
-#
-#      - name: Install web app
-#        if: steps.yarn-cache.outputs.cache-hit != 'true'
-#        run: yarn install --frozen-lockfile --prefer-offline
-#        working-directory: web
-#
-#      - name: Set up Python
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.11'
-#
-#      - name: Install latest version of pip
-#        run: pip install --upgrade pip
-#
-#      - uses: actions/cache@v3
-#        id: pip-cache
-#        with:
-#          path: ${{ env.pythonLocation}}/lib/python3.11/site-packages/*
-#          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('setup.py') }}
-#
-#      - name: Install dandi-api dependencies
-#        run: pip install --upgrade --upgrade-strategy eager -e .[dev]
-#
-#      - name: Apply migrations to API server
-#        run: python manage.py migrate
-#
-#      - name: Create any cache tables
-#        run: python manage.py createcachetable
-#
-#      - name: Install E2E tests
-#        run: yarn install --frozen-lockfile
-#        working-directory: e2e
-#
-#      - name: Lint E2E tests
-#        run: yarn run lint --no-fix --max-warnings=0
-#        working-directory: e2e
-#
-#      - name: Run E2E tests
-#        run: |
-#          # start vue dev server and wait for it to start
-#          yarn --cwd ../web/ run dev 2> /dev/null &
-#          while ! nc -z localhost 8085; do
-#            sleep 3
-#          done
-#
-#          # start the dandi-api server
-#          python ../manage.py runserver &
-#
-#          # run the E2E tests
-#          yarn run test
-#        working-directory: e2e
+  test-e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: django
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq:management
+        ports:
+          - 5672:5672
+      minio:
+        # This image does not require any command arguments (which GitHub Actions don't support)
+        image: bitnami/minio:latest
+        env:
+          MINIO_ROOT_USER: minioAccessKey
+          MINIO_ROOT_PASSWORD: minioSecretKey
+        ports:
+          - 9000:9000
+    env:
+      # API server env vars
+      DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
+      DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
+      DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
+      DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
+      DJANGO_STORAGE_BUCKET_NAME: dandi-bucket
+      DJANGO_DANDI_DANDISETS_BUCKET_NAME: dandi-bucket
+      DJANGO_DANDI_DANDISETS_LOG_BUCKET_NAME: dandiapi-dandisets-logs
+      DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_NAME: dandi-embargo-dandisets
+      DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME: dandiapi-embargo-dandisets-logs
+      DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
+      DJANGO_DANDI_API_URL: http://localhost:8000
+      DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org/
+      DANDI_ALLOW_LOCALHOST_URLS: 1
+
+      # Web client env vars
+      VITE_APP_DANDI_API_ROOT: http://localhost:8000/api/
+      VITE_APP_OAUTH_API_ROOT: http://localhost:8000/oauth/
+      VITE_APP_OAUTH_CLIENT_ID: Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl
+
+      # E2E tests env vars
+      CLIENT_URL: http://localhost:8085
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'yarn'
+          cache-dependency-path: web/yarn.lock
+
+      - name: Install web app
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --prefer-offline
+        working-directory: web
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install latest version of pip
+        run: pip install --upgrade pip
+
+      - uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ${{ env.pythonLocation}}/lib/python3.11/site-packages/*
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('setup.py') }}
+
+      - name: Install dandi-api dependencies
+        run: pip install --upgrade --upgrade-strategy eager -e .[dev]
+
+      - name: Apply migrations to API server
+        run: python manage.py migrate
+
+      - name: Create any cache tables
+        run: python manage.py createcachetable
+
+      - name: Install E2E tests
+        run: yarn install --frozen-lockfile
+        working-directory: e2e
+
+      - name: Lint E2E tests
+        run: yarn run lint --no-fix --max-warnings=0
+        working-directory: e2e
+
+      - name: Run E2E tests
+        run: |
+          # start vue dev server and wait for it to start
+          yarn --cwd ../web/ run dev 2> /dev/null &
+          while ! nc -z localhost 8085; do
+            sleep 3
+          done
+
+          # start the dandi-api server
+          python ../manage.py runserver &
+
+          # run the E2E tests
+          yarn run test
+        working-directory: e2e

--- a/e2e/setenv.sh
+++ b/e2e/setenv.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Invoke "source setenv.sh" to populate environment variables locally
+
+export DJANGO_DATABASE_URL="postgres://postgres:postgres@localhost:5432/django"
+export DJANGO_MINIO_STORAGE_ENDPOINT="localhost:9000"
+export DJANGO_MINIO_STORAGE_ACCESS_KEY="minioAccessKey"
+export DJANGO_MINIO_STORAGE_SECRET_KEY="minioSecretKey"
+export DJANGO_STORAGE_BUCKET_NAME="dandi-bucket"
+export DJANGO_DANDI_DANDISETS_BUCKET_NAME="dandi-bucket"
+export DJANGO_DANDI_DANDISETS_LOG_BUCKET_NAME="dandiapi-dandisets-logs"
+export DJANGO_DANDI_DANDISETS_EMBARGO_BUCKET_NAME="dandi-embargo-dandisets"
+export DJANGO_DANDI_DANDISETS_EMBARGO_LOG_BUCKET_NAME="dandiapi-embargo-dandisets-logs"
+export DJANGO_DANDI_WEB_APP_URL="http://localhost:8085"
+export DJANGO_DANDI_API_URL="http://localhost:8000"
+export DJANGO_DANDI_JUPYTERHUB_URL="https://hub.dandiarchive.org/"
+export DANDI_ALLOW_LOCALHOST_URLS="1"
+export VITE_APP_DANDI_API_ROOT="http://localhost:8000/api/"
+export VITE_APP_OAUTH_API_ROOT="http://localhost:8000/oauth/"
+export VITE_APP_OAUTH_CLIENT_ID="Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
+export CLIENT_URL="http://localhost:8085"


### PR DESCRIPTION
Tests are breaking for two reasons

- `DandisetViewset` API Viewset requires all visitors to be approved, otherwise a 401 occurs -- thus the test suite needs to be updated for that

- OAuth local is failing on registering a new user (e.g. 404s are occuring), thus I need to look further into this for why it fails on LINC but not DANDI