### PR TITLE
Add design doc for a manual annotation tool

### DIFF
--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -28,7 +28,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 4. Annotate branching axon bundles
 5. Store two annotations for a subset of axon bundles
 6. Annotate 1-3 unique axon bundles per slice
-7. Augment labeled datasets
+7. Team-based augmentation of labeled datasets
 8. Add landmarks
 9. Pixel-wise classifier (i.e. trace individual axons)
 10. Create other labels used to evaluate automated methods - Need to specify further.

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -38,10 +38,6 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 14. Filter streamlines that pass through a region of interest
 15. View multiple imaging layers in the same view
 
-## Open questions
-
-1. What storage format should be used for the two different annotation types?  Zarr?
-2. How are the annotations stored?  In a bucket or database within the container?
 ## Possible solutions
 
 ### Neuroglancer
@@ -61,5 +57,14 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 - Last updated in May 2022
 
 ### WEBKNOSSOS
+References
+- Web application - [Source code](https://github.com/scalableminds/webknossos)
+- Python API - [Source code](https://github.com/scalableminds/webknossos-libs) and [docs](https://docs.webknossos.org/webknossos-py/)
+- REST API is deprecated
+Skeleton annotations
+- Draw line segments with branching
+- Stored in [NML file format](https://docs.webknossos.org/webknossos/data_formats.html#nml-files)
+
+#### Open questions
 
 ### CAVE

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -7,7 +7,7 @@ As additional use cases and requirements are defined they will be added in follo
 
 ### Use case 1 - Manual annotation of axon bundles
 
-Outline axon bundles on 2D slices to create volumetric segmentations.  For example segmentations see [Sundaresan et al., bioRxiv 2023](https://doi.org/10.1101/2023.09.30.560310).
+Outline axon bundles on 2D slices to create volumetric segmentations.  For example segmentations see [Sundaresan et al., bioRxiv 2023](https://doi.org/10.1101/2023.09.30.560310) which were generated in Neurolucida.
 
 Annotation of axon bundles will occur in the following data modalities:
 1. Optical microscopy of histological sections of axon tracers

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -62,15 +62,24 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 - Has SmartInterpol been integrated with Neuroglancer or NeuroTrALE?
 
 ### WEBKNOSSOS
+
 References
+- [Homepage](https://weblium.webknossos.org/)
 - [Docs](https://docs.webknossos.org/webknossos/index.html)
-- Web application - [Source code](https://github.com/scalableminds/webknossos)
-- Python API - [Source code](https://github.com/scalableminds/webknossos-libs) and [docs](https://docs.webknossos.org/webknossos-py/)
+- Web application
+    - [Source code](https://github.com/scalableminds/webknossos)
+- Python API
+    - [Source code](https://github.com/scalableminds/webknossos-libs)
+    - [Docs](https://docs.webknossos.org/webknossos-py/)
 - REST API is deprecated
 
 Volume annotations
 - [Docs](https://docs.webknossos.org/webknossos/volume_annotation.html)
 - Summary - Voxel-wise segmentation
+- Features
+    - Brush tool
+    - Interpolation between slices
+    - AI-based quick-select tool with a bounding box. Not available in open-source version.
 - [Supported data formats](https://docs.webknossos.org/webknossos/data_formats.html): WKW, OME-Zarr/NGFF, Precomputed, N5, Image Stacks
 - "The WEBKNOSSOS-wrap (WKW) container format is used for all internal voxel data representations - both for the raw (microscopy) image datasets and segmentations."
 
@@ -79,13 +88,37 @@ Skeleton annotations
 - Summary - Draw line segments with branching
 - Supported data format: [NML file format](https://docs.webknossos.org/webknossos/data_formats.html#nml-files)
 
-Proof of concept deployment
+Pricing
+- [Plans](https://webknossos.org/pricing#compare-plans)
+- [Features for each plan](https://webknossos.org/pricing#custom-4)
+
+Proof of concept deployment notes
+- POC available at https://webknossos-staging.lincbrain.org/
 - User management on webknossos app is independent from lincbrain.org.
-- Vendor accounts
+- Set up vendor accounts
     - [Docker Hub](https://hub.docker.com/u/lincbrain])
     - CircleCI
-- POC available at https://webknossos-staging.lincbrain.org/
+- Local deployment provides faster iteration of testing changes rather than deploying Docker containers via CircleCI pipeline
+- AWS credentials are not encrypted in requests, fortunately SSL present, sent over HTTP/2
+
 
 #### Open questions
+
+1. Deployment
+    1. *The EC2 instance type is prescribed by the documentation.  Does WebKNOSSOS have auto-scaling set up? ECS?
+    1. *Does webknossos provide monitoring of backend resources? Does it rely on AWS-based metrics with alerts or another mechansim?
+    1. For local deployment, React/TS is not recognized by Chrome browser extensions
+
+1. Application
+    1. *How are the annotations backed up?
+    1. When fetching assets from S3, why is the server called? Why not just retrieve from S3 directly?
+
+1. Data management
+    1. *How are annotation files stored?  In the database within the container? 
+    1. Is there support for NIfTI files?
+1. User interface
+    1. Dataset and annotation versioning
+1. Custom development
+    1. What would it look like to set up a contract for custom development that we may need on the WEBKNOSSOS backend or frontend?
 
 ### CAVE

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -44,12 +44,6 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 
 ## Possible solutions
 
-### Neuroglancer
-
-- Web-based, mutli-scale volumetric data visualization
-- Source code - https://github.com/google/neuroglancer
-- Does not natively include features for voxel-wise segmentation or annotation management.
-
 ### NeuroTrALE
 
 # NeuroTrALE Data Manager
@@ -144,6 +138,12 @@ Proof of concept notes
 ## Alternative annotation tools
 
 The following tools have been evaluated against the LINC use cases and requirements, and will not be implemented for the LINC project.
+
+### Neuroglancer
+
+- Web-based, mutli-scale volumetric data visualization
+- Source code - https://github.com/google/neuroglancer
+- Does not natively include features for voxel-wise segmentation or annotation management.
 
 ### HortaCloud
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -1,5 +1,7 @@
 # Add manual annotation tool for the LINC Project
 
+Authors: Kabilar Gunalan, Aaron Kanzer
+
 Outlined in this document are the manual annotation use cases for the 5 year LINC project.
 With the information at hand, we will select and deploy an annotation framework.
 As additional use cases and requirements are defined they will be added in follow up design documents.
@@ -49,6 +51,12 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 - Does not natively include features for voxel-wise segmentation or annotation management.
 
 ### NeuroTrALE
+
+# NeuroTrALE Data Manager
+
+- [Source code](https://github.com/mit-ll/NeuroTrALE-data-manager)
+- The NeuroTrALE Data Manager is also referred to as the NeuroTrALE Precomputed Service.
+- "The NeuroTrALE Precomputed Service simply serves up existing imagery and annotations, and allows updating annotations. The imagery (image tiles) are ingested by using MIT's precomputed-tif tool, which takes a stack of tiff images and generates a directory tree of tiff files. Refer to https://github.com/chunglabmit/precomputed-tif."
 
 ### SmartInterpol
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -67,6 +67,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 References
 - [Homepage](https://weblium.webknossos.org/)
 - [Docs](https://docs.webknossos.org/webknossos/index.html)
+- [Roadmap](https://webknossos.org/roadmap)
 - Web application
     - [Source code](https://github.com/scalableminds/webknossos)
 - Python API
@@ -92,6 +93,13 @@ Skeleton annotations
 Pricing
 - [Plans](https://webknossos.org/pricing#compare-plans)
 - [Features for each plan](https://webknossos.org/pricing#custom-4)
+
+Application notes
+- Annotations
+    - Stored in [FossilDB](https://github.com/scalableminds/fossildb), which is a key-value store that is built on RocksDB.
+    - Annotations can be accessed using the webknossos Python API, but should not be accessed directly through the FossilDB CLI.  The Python API will return the volume annotations (as a Zarr), the skeleton annotations, or bounding boxes.
+    - Annotations can be backed up by taking a snapshot of the database using the [FossilDB CLI](https://github.com/scalableminds/fossildb?tab=readme-ov-file#installation--usage).
+    - Annotations are versioned but each version is not available through the Python API.
 
 Proof of concept notes
 - POC available at https://webknossos-staging.lincbrain.org/

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -56,6 +56,10 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 - Input image and label volumes, and output label volumes should be in NIfTI format
 - Last updated in May 2022
 
+### Open questions
+
+- Has SmartInterpol been integrated with Neuroglancer or NeuroTrALE?
+
 ### WEBKNOSSOS
 References
 - Web application - [Source code](https://github.com/scalableminds/webknossos)

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -44,26 +44,6 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 
 ## Possible solutions
 
-### NeuroTrALE
-
-# NeuroTrALE Data Manager
-
-- [Source code](https://github.com/mit-ll/NeuroTrALE-data-manager)
-- The NeuroTrALE Data Manager is also referred to as the NeuroTrALE Precomputed Service.
-- "The NeuroTrALE Precomputed Service simply serves up existing imagery and annotations, and allows updating annotations. The imagery (image tiles) are ingested by using MIT's precomputed-tif tool, which takes a stack of tiff images and generates a directory tree of tiff files. Refer to https://github.com/chunglabmit/precomputed-tif."
-
-### SmartInterpol
-
-- Summary - "Smart Interpol is a semi-automated segmentation tool which, starting from a volume with a sparse subset of manually labelled slices, estimates the corresponding dense segmentation in an automated fashion."
-- Source code - https://github.com/aleatzeni/SmartInterpol
-- MATLAB-based package
-- Input image and label volumes, and output label volumes should be in NIfTI format
-- Last updated in May 2022
-
-### Open questions
-
-- Has SmartInterpol been integrated with Neuroglancer or NeuroTrALE?
-
 ### WEBKNOSSOS
 
 References
@@ -133,11 +113,10 @@ Proof of concept notes
 
 1. Custom development
     1. What would it look like to set up a contract for custom development that we may need on the WEBKNOSSOS backend or frontend?
-
-### CAVE
+        
 ## Alternative annotation tools
 
-The following tools have been evaluated against the LINC use cases and requirements, and will not be implemented for the LINC project.
+The following tools have been evaluated against the LINC use cases and requirements, and will not be implemented for the LINC project based on the takeaways listed below.
 
 ### Neuroglancer
 
@@ -153,6 +132,75 @@ Takeaway
 
 Does not natively include features for voxel-based segmentation, data management, or user management.
 
+### NeuroTrALE
+
+Summary
+
+NeuroTrALE is a framework that allows for creating, storing, and editing annotations of line segments and polygons.  NeuroTrALE includes the segmentation algorithm (Axon Centerline Detection), data management system (NeuroTrALE Data Manager, also referred to as the NeuroTrALE Precomputed Service), and front-end visualization and editing interface that is built on Neuroglancer (NeuroTrALE UI).
+
+References
+
+- [UI Snapshot 1.4 source code](https://github.com/mit-ll/NeuroTrALE-ui/tree/1.4.0-SNAPSHOT)
+- [UI Snapshot 2.0 source code](https://github.com/mit-ll/NeuroTrALE-ui/tree/2.0.0-SNAPSHOT)
+- [Data manager source code](https://github.com/mit-ll/NeuroTrALE-data-manager)
+- [Axon centerline detection source code](https://github.com/mit-ll/axon-centerline-detection)
+
+Details
+
+1. The NeuroTrALE UI allows for creating polygons and line strings using control points.
+2. The NeuroTrALE Precomputed Service only works with [Precomputed TIFF Files](https://github.com/chunglabmit/precomputed-tif).
+3. Each imaging dataset is tied to a single set of annotation files.  See [Filesystem docs](https://github.com/mit-ll/NeuroTrALE-data-manager?tab=readme-ov-file#filesystem). 
+4. Multiple users can edit the annotations for a dataset simulatenously but the last user to save their annotations overwrites all other versions, thereby leading to a race condition.
+
+Future developments
+
+1. Integrate UI Snapshot 2.0 with the base Google Neuroglancer fork.
+2. Toolbar with command shortcuts
+
+Proof of concept
+
+
+
+Takeaways
+
+1. Does not include a feature for voxel-wise segmentations (Requirement 9).
+2. Does not allow for storing multiple annotations for a given dataset (Requirement 5).
+
+
+### Smart Interpol
+
+Summary
+
+"Smart Interpol is a semi-automated segmentation tool which, starting from a volume with a sparse subset of manually labelled slices, estimates the corresponding dense segmentation in an automated fashion."
+
+References
+
+1. [Source code](https://github.com/aleatzeni/SmartInterpol)
+1. [Atzeni et al., MICCAI 2018](https://link.springer.com/chapter/10.1007/978-3-030-00934-2_25)
+
+Details
+
+1. MATLAB-based package
+1. Input image and label volumes, and output label volumes should be in the NIfTI file format.
+1. Last updated in May 2002
+
+Takeaways
+
+1. Would need to be integrated with NeuroTrALE to interactively compute and render dense segmentations.
+
+### CAVE
+
+Summary
+
+References
+
+1. [Documentation](https://caveconnectome.github.io/CAVEclient/)
+1. [Source code](https://github.com/CAVEconnectome)
+1. [Dorkenwald et al. 2023](https://doi.org/10.1101/2023.07.26.550598)
+
+Takeaways
+
+
 ### HortaCloud
 
 Summary
@@ -165,6 +213,6 @@ References
 1. [Docs](https://hortacloud.janelia.org/docs/)
 1. [Source code](https://github.com/JaneliaSciComp/hortacloud)
 
-Takeaway
+Takeaways
 
-Does not provide for voxel-based segmentations.
+1. Does not include a feature for voxel-wise segmentations (Requirement 9).

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -37,7 +37,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 ## Open questions
 
 1. What storage format should be used for the two different annotation types?  Zarr?
-
+2. How are the annotations stored?  In a bucket or database within the container?
 ## Possible solutions
 
 ### Neuroglancer

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -36,6 +36,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 12. Make annotations available for dissemination
 13. Visualize streamlines
 14. Filter streamlines that pass through a region of interest
+15. View multiple imaging layers in the same view
 
 ## Open questions
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -141,3 +141,22 @@ Proof of concept notes
     1. What would it look like to set up a contract for custom development that we may need on the WEBKNOSSOS backend or frontend?
 
 ### CAVE
+## Alternative annotation tools
+
+The following tools have been evaluated against the LINC use cases and requirements, and will not be implemented for the LINC project.
+
+### HortaCloud
+
+Summary
+
+Annotation platform from the Janelia Research Campus.  The cloud-based platform allows for visualization of large-scale 3D microscopy data and creating skeletons of neurons by manually annotating points in 3D space.
+
+References
+
+1. [Homepage](https://hortacloud.janelia.org/)
+1. [Docs](https://hortacloud.janelia.org/docs/)
+1. [Source code](https://github.com/JaneliaSciComp/hortacloud)
+
+Takeaway
+
+Does not provide for voxel-based segmentations.

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -31,7 +31,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 7. Augment labeled datasets
 8. Add landmarks
 9. Pixel-wise classifier (i.e. trace individual axons)
-10. Create other labels used to evaluate automated methods
+10. Create other labels used to evaluate automated methods - Need to specify further.
 11. Make annotations available for dissemination
 
 ## Open questions

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -92,7 +92,7 @@ Pricing
 - [Plans](https://webknossos.org/pricing#compare-plans)
 - [Features for each plan](https://webknossos.org/pricing#custom-4)
 
-Proof of concept deployment notes
+Proof of concept notes
 - POC available at https://webknossos-staging.lincbrain.org/
 - User management on webknossos app is independent from lincbrain.org.
 - Set up vendor accounts
@@ -100,24 +100,26 @@ Proof of concept deployment notes
     - CircleCI
 - Local deployment provides faster iteration of testing changes rather than deploying Docker containers via CircleCI pipeline
 - AWS credentials are not encrypted in requests, fortunately SSL present, sent over HTTP/2
-
+- Making webknossos instance a “LINC Archive” User so that a valid API Key exists
 
 #### Open questions
 
 1. Deployment
     1. *The EC2 instance type is prescribed by the documentation.  Does WebKNOSSOS have auto-scaling set up? ECS?
-    1. *Does webknossos provide monitoring of backend resources? Does it rely on AWS-based metrics with alerts or another mechansim?
-    1. For local deployment, React/TS is not recognized by Chrome browser extensions
+    2. *Does webknossos provide monitoring of backend resources? Does it rely on AWS-based metrics with alerts or another mechansim?
+    3. Blue/green deployments? Canary releases? Noticed API versioning....
+    4. CircleCI consistently fails on "Build webknossos docker image" unless target/is invoked locally first
+    5. For local deployment, unable to render remote assets (e.g. Public Zarr asset on S3)
+    6. For local deployment, React/TS is not recognized by Chrome browser extensions
 
 1. Application
-    1. *How are the annotations backed up?
     1. When fetching assets from S3, why is the server called? Why not just retrieve from S3 directly?
+    2. Is there support for visualizing NIfTI files?
+    3. *How are annotations stored?  In the database within the container? 
+    4. *How are annotations versioned?
+    5. *How are the annotations backed up?
+    6. *Since a `Reload` can be performed on a `Dataset`, how does a user know that a given annotation corresponds a specific version of the imaging data?
 
-1. Data management
-    1. *How are annotation files stored?  In the database within the container? 
-    1. Is there support for NIfTI files?
-1. User interface
-    1. Dataset and annotation versioning
 1. Custom development
     1. What would it look like to set up a contract for custom development that we may need on the WEBKNOSSOS backend or frontend?
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -48,6 +48,14 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 
 ### NeuroTrALE
 
+### SmartInterpol
+
+- Summary - "Smart Interpol is a semi-automated segmentation tool which, starting from a volume with a sparse subset of manually labelled slices, estimates the corresponding dense segmentation in an automated fashion."
+- Source code - https://github.com/aleatzeni/SmartInterpol
+- MATLAB-based package
+- Input image and label volumes, and output label volumes should be in NIfTI format
+- Last updated in May 2022
+
 ### WEBKNOSSOS
 
 ### CAVE

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -46,6 +46,10 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 
 ### Neuroglancer
 
+- Web-based, mutli-scale volumetric data visualization
+- Source code - https://github.com/google/neuroglancer
+- Does not natively include features for voxel-wise segmentation or annotation management.
+
 ### NeuroTrALE
 
 ### SmartInterpol

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -1,6 +1,7 @@
 # Add manual annotation tool for the LINC Project
 
 Outlined in this document are the manual annotation use cases for the 5 year LINC project.
+With the information at hand, we will select and deploy an annotation framework.
 As additional use cases and requirements are defined they will be added in follow up design documents.
 
 ## Use cases 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -62,12 +62,28 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 
 ### WEBKNOSSOS
 References
+- [Docs](https://docs.webknossos.org/webknossos/index.html)
 - Web application - [Source code](https://github.com/scalableminds/webknossos)
 - Python API - [Source code](https://github.com/scalableminds/webknossos-libs) and [docs](https://docs.webknossos.org/webknossos-py/)
 - REST API is deprecated
+
+Volume annotations
+- [Docs](https://docs.webknossos.org/webknossos/volume_annotation.html)
+- Summary - Voxel-wise segmentation
+- [Supported data formats](https://docs.webknossos.org/webknossos/data_formats.html): WKW, OME-Zarr/NGFF, Precomputed, N5, Image Stacks
+- "The WEBKNOSSOS-wrap (WKW) container format is used for all internal voxel data representations - both for the raw (microscopy) image datasets and segmentations."
+
 Skeleton annotations
-- Draw line segments with branching
-- Stored in [NML file format](https://docs.webknossos.org/webknossos/data_formats.html#nml-files)
+- [Docs](https://docs.webknossos.org/webknossos/skeleton_annotation.html)
+- Summary - Draw line segments with branching
+- Supported data format: [NML file format](https://docs.webknossos.org/webknossos/data_formats.html#nml-files)
+
+Proof of concept deployment
+- User management on webknossos app is independent from lincbrain.org.
+- Vendor accounts
+    - [Docker Hub](https://hub.docker.com/u/lincbrain])
+    - CircleCI
+- POC available at https://webknossos-staging.lincbrain.org/
 
 #### Open questions
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -128,9 +128,9 @@ References
 
 1. [Source code](https://github.com/google/neuroglancer)
 
-Takeaway
+Takeaways
 
-Does not natively include features for voxel-based segmentation, data management, or user management.
+1. Does not natively include features for voxel-based segmentation, data management, or user management.
 
 ### NeuroTrALE
 
@@ -151,6 +151,7 @@ Details
 2. The NeuroTrALE Precomputed Service only works with [Precomputed TIFF Files](https://github.com/chunglabmit/precomputed-tif).
 3. Each imaging dataset is tied to a single set of annotation files.  See [Filesystem docs](https://github.com/mit-ll/NeuroTrALE-data-manager?tab=readme-ov-file#filesystem). 
 4. Multiple users can edit the annotations for a dataset simulatenously but the last user to save their annotations overwrites all other versions, thereby leading to a race condition.
+5. Currently deployed on Lincoln Lab servers for internal use, and MIT SuperCloud for the MIT Chung Lab and collaborators of the Chung Lab at the University of Florida.
 
 Future developments
 
@@ -200,6 +201,7 @@ References
 
 Takeaways
 
+1. Does not include a feature for voxel-wise segmentations (Requirement 9).
 
 ### HortaCloud
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -38,6 +38,7 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 13. Visualize streamlines
 14. Filter streamlines that pass through a region of interest
 15. View multiple imaging layers in the same view
+16. ?View NIfTI and/or NIfTI-Zarr files
 
 ## Possible solutions
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -1,0 +1,49 @@
+# Add manual annotation tool for the LINC Project
+
+Outlined in this document are the manual annotation use cases for the 5 year LINC project.
+As additional use cases and requirements are defined they will be added in follow up design documents.
+
+## Use cases 
+
+### Use case 1 - Manual annotation of axon bundles
+
+Outline axon bundles on 2D slices to create volumetric segmentations.  For example segmentations see [Sundaresan et al., bioRxiv 2023](https://doi.org/10.1101/2023.09.30.560310).
+
+Annotation of axon bundles will occur in the following data modalities:
+1. Optical microscopy of histological sections of axon tracers
+2. Light-sheet microscopy (LSM) sections of axonal markers
+3. Hierarchical Phase-Contrast Tomography (HiP-CT)
+
+### Use case 2 - Manual annotation of individual axons
+
+Pixel-wise classifier of micro-CT images.
+
+Similar segmentations were previously performed on electron microscopy (EM) images.  Labels were created for artifacts, myelin, intracellular spaces, and extracellular spaces.  These manual segmentations were performed in FslView and saved in NIfTI files.  The manuscript for this work is currently being prepared.
+
+## Requirements
+
+1. Cloud-based manual annotation tool
+2. Annotation tool should integrate with centralized data on AWS S3
+3. Annotate axon bundles
+4. Annotate branching axon bundles
+5. Store two annotations for a subset of axon bundles
+6. Annotate 1-3 unique axon bundles per slice
+7. Augment labeled datasets
+8. Add landmarks
+9. Pixel-wise classifier (i.e. trace individual axons)
+10. Create other labels used to evaluate automated methods
+11. Make annotations available for dissemination
+
+## Open questions
+
+1. What storage format should be used for the two different annotation types?  Zarr?
+
+## Possible solutions
+
+### Neuroglancer
+
+### NeuroTrALE
+
+### WEBKNOSSOS
+
+### CAVE

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -141,9 +141,17 @@ The following tools have been evaluated against the LINC use cases and requireme
 
 ### Neuroglancer
 
-- Web-based, mutli-scale volumetric data visualization
-- Source code - https://github.com/google/neuroglancer
-- Does not natively include features for voxel-wise segmentation or annotation management.
+Summary
+
+Web-based, multi-scale volumetric data visualization.
+
+References
+
+1. [Source code](https://github.com/google/neuroglancer)
+
+Takeaway
+
+Does not natively include features for voxel-based segmentation, data management, or user management.
 
 ### HortaCloud
 

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -218,3 +218,15 @@ References
 Takeaways
 
 1. Does not include a feature for voxel-wise segmentations (Requirement 9).
+
+## Zooniverse
+
+Summary
+
+The Zooniverse team is currently working on their first implementation of a volumetric annotation tool in collaboration with the Center for Mesoscale Connectomics (CMC).  Their goal is to release this feature at the end of the CMC UM1 Year 2.  We will work with the Zooniverse and CMC teams to alpha/beta test this annotation tool as releases are made available over the course of this year.
+
+References
+
+1. [Homepage](https://www.zooniverse.org)
+1. [Zooniverse + CMC Presentation](https://docs.google.com/presentation/d/1Xl0AhVDM2z9mVE5IcnWMTXQRndk7K3WTrEbDjKvTYLM/edit#slide=id.g276e378112e_0_0)
+1. [Source code](https://github.com/zooniverse)

--- a/doc/design/linc-annotation.md
+++ b/doc/design/linc-annotation.md
@@ -31,8 +31,11 @@ Similar segmentations were previously performed on electron microscopy (EM) imag
 7. Team-based augmentation of labeled datasets
 8. Add landmarks
 9. Pixel-wise classifier (i.e. trace individual axons)
-10. Create other labels used to evaluate automated methods - Need to specify further.
-11. Make annotations available for dissemination
+10. Interpolate pixel-wise segmentations between slices
+11. Create other labels used to evaluate automated methods - Need to specify further.
+12. Make annotations available for dissemination
+13. Visualize streamlines
+14. Filter streamlines that pass through a region of interest
 
 ## Open questions
 


### PR DESCRIPTION
- [x] After discussion with Anastasia and Hong-Hsi, we have defined 2 use cases.
- [x] I have collated the requirements from the milestones final document and the above use cases.  My local copy of this design doc matches each requirement to a milestone number.  I have not pushed these milestone numbers to GitHub since we probably don't want specific information on the milestones to be public.
- [ ] Evaluate possible solutions and add a description of the evaluations to this document

cc @aaronkanzer @ayendiki @satra 