### PR TITLE
Update user count to approved users in stats_view endpoint

### DIFF
--- a/dandiapi/api/tests/test_stats.py
+++ b/dandiapi/api/tests/test_stats.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+from dandiapi.api.models import UserMetadata
+from django.contrib.auth.models import User
 
 import pytest
-
 
 @pytest.mark.django_db()
 def test_stats_baseline(api_client):
@@ -33,10 +34,20 @@ def test_stats_published(api_client, published_version_factory):
 
 @pytest.mark.django_db()
 def test_stats_user(api_client, user):
+
+    # Create users with different statuses
+    approved_user_count = 0
+    for status in UserMetadata.Status.choices:
+        user = User.objects.create(username=f'{status.lower()}_user')
+        UserMetadata.objects.create(user=user, status=status)
+        if status == UserMetadata.Status.APPROVED:
+            approved_user_count += 1
+
     stats = api_client.get('/api/stats/').data
 
-    # django-guardian automatically creates an AnonymousUser
-    assert stats['user_count'] == 2
+    # Assert that the user count only includes users with APPROVED status
+    assert stats['user_count'] == 1
+    assert stats['user_count'] == approved_user_count
 
 
 @pytest.mark.django_db()

--- a/dandiapi/api/views/stats.py
+++ b/dandiapi/api/views/stats.py
@@ -5,7 +5,7 @@ from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from dandiapi.api.models import Asset, Dandiset
+from dandiapi.api.models import Asset, Dandiset, UserMetadata
 
 
 # Cache this response for 12 hours
@@ -14,7 +14,7 @@ from dandiapi.api.models import Asset, Dandiset
 def stats_view(self):
     dandiset_count = Dandiset.objects.count()
     published_dandiset_count = Dandiset.published_count()
-    user_count = User.objects.count()
+    user_count = User.objects.filter(metadata__status=UserMetadata.Status.APPROVED).count()
     size = Asset.total_size()
     return Response(
         {


### PR DESCRIPTION
![Screenshot 2024-05-22 at 12 06 33 PM](https://github.com/lincbrain/linc-archive/assets/36093535/0ea9b7f0-8899-49f8-bc8e-bd12c48dfb26)


On the homepage, a user count is described. Prior to this PR, this user count included all users (even those rejected). This PR updates the count to be only APPROVED users included in the count

Cc @kabilar 