### PR TITLE
Include text wrap CSS prop for text on cookie message in UI

### DIFF
--- a/web/src/components/AppBar/UserMenu.vue
+++ b/web/src/components/AppBar/UserMenu.vue
@@ -25,10 +25,10 @@
         </v-list-item-content>
         <v-list-item-action>
           <v-icon>mdi-cookie</v-icon>
-          <span v-if="cookiesRequestSuccess == 1" style="color: green; margin-left: 10px;">
+          <span v-if="cookiesRequestSuccess == 1" style="color: green; margin-left: 10px; text-wrap: wrap; max-width: 150px;">
             Success! Expires in 30 days
           </span>
-          <span v-if="cookiesRequestSuccess == -1" style="color: red; margin-left: 10px;">
+          <span v-if="cookiesRequestSuccess == -1" style="color: red; margin-left: 10px; text-wrap: wrap; max-width: 150px;">
             Unable to get cookies
           </span>
         </v-list-item-action>


### PR DESCRIPTION
Cc @kabilar -- this should resolve the issue we were seeing with the cookie message not wrapping in the UI/going off the screen

<img width="346" alt="Screenshot 2024-06-04 at 11 24 52 AM" src="https://github.com/lincbrain/linc-archive/assets/36093535/e6accc8c-fbb0-468d-862f-2245936072d4">
