### PR TITLE
Replace the DANDI Google Analytics tag with LINC tag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,15 +8,6 @@
     <title>LINC Data Platform</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6DJVBYNZRW"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-6DJVBYNZRW');
-    </script>
   </head>
   <body>
     <noscript>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -47,7 +47,7 @@ Sentry.init({
 });
 
 Vue.use(VueGtag, {
-  config: { id: 'UA-146135810-2' },
+  config: { id: 'G-6DJVBYNZRW' },
 }, router);
 
 Vue.use(VueSocialSharing);


### PR DESCRIPTION
Fix #221 

The LINC Data Platform was still populating the DANDI Google Analytics account so I replaced the DANDI GA tag with the LINC GA tag.

@aaronkanzer Do we need the JS for the Google Analytics tag in `web/index.html`?  I removed it in this pull request.