### PR TITLE
Update Neuroglancer layer type so that the user does not need to select `Create as image layer`

### DIFF
--- a/dandiapi/api/views/private_s3_permissions.py
+++ b/dandiapi/api/views/private_s3_permissions.py
@@ -27,7 +27,7 @@ def construct_neuroglancer_url(source, layer_name):
     json_object = {
         "layers": [
             {
-                "type": "new",
+                "type": "image",
                 "source": source,
                 "tab": "source",
                 "name": layer_name


### PR DESCRIPTION
## Description of the issue
Currently, when a user selects `External Services > Neuroglancer` on the LINC Data Platform, they are routed to neuroglancer.lincbrain.org and must select `Create as image layer`.  See example URL and screenshot below.

```
https://neuroglancer.lincbrain.org/cloudfront/frontend/index.html#!%7B%22dimensions%22:%7B%22x%22:%5B0.0000021949999999999997%2C%22m%22%5D%2C%22y%22:%5B0.0000021949999999999997%2C%22m%22%5D%2C%22z%22:%5B0.0000021949999999999997%2C%22m%22%5D%7D%2C%22position%22:%5B4726.5%2C4726.5%2C5728.5%5D%2C%22crossSectionScale%22:1%2C%22projectionScale%22:16384%2C%22layers%22:%5B%7B%22type%22:%22new%22%2C%22source%22:%22zarr://https://neuroglancer.lincbrain.org/zarr/fa22b3b8-9950-4859-b674-ba60bda2da19/%22%2C%22tab%22:%22source%22%2C%22name%22:%22fa22b3b8-9950-4859-b674-ba60bda2da19%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22fa22b3b8-9950-4859-b674-ba60bda2da19%22%7D%2C%22layout%22:%224panel%22%7D
```

![image](https://github.com/user-attachments/assets/4515da80-937e-4492-93a2-15d4b7d047d7)

When the `Create as image layer` button is pressed the URL is as follows:

```
https://neuroglancer.lincbrain.org/cloudfront/frontend/index.html#!%7B%22dimensions%22:%7B%22x%22:%5B0.0000021949999999999997%2C%22m%22%5D%2C%22y%22:%5B0.0000021949999999999997%2C%22m%22%5D%2C%22z%22:%5B0.0000021949999999999997%2C%22m%22%5D%7D%2C%22position%22:%5B4726.5%2C4726.5%2C5728.5%5D%2C%22crossSectionScale%22:1%2C%22projectionScale%22:16384%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22zarr://https://neuroglancer.lincbrain.org/zarr/fa22b3b8-9950-4859-b674-ba60bda2da19/%22%2C%22tab%22:%22source%22%2C%22name%22:%22fa22b3b8-9950-4859-b674-ba60bda2da19%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22fa22b3b8-9950-4859-b674-ba60bda2da19%22%7D%2C%22layout%22:%224panel%22%7D
```

The only difference between the URLs is that the `type` is `new` vs `image`.

## Proposed solution

The proposed change creates the image layer through the json state so the user doesn't need to perform this step.