### PR TITLE
Use correct import for OAuth client

### DIFF
--- a/web/src/rest.ts
+++ b/web/src/rest.ts
@@ -1,7 +1,7 @@
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
 import { ref } from 'vue';
-import OAuthClient from '@girder/oauth-client';
+import OAuthClient from '@resonant/oauth-client';
 import type {
   Asset,
   Dandiset,


### PR DESCRIPTION
Resolves build error from importing old OAuth Client library

Cc @kabilar -- this should fix the build in Netlify and deploy other UI changes we had done prior